### PR TITLE
Add badge page with responsive placeholders

### DIFF
--- a/src/Student.js
+++ b/src/Student.js
@@ -50,6 +50,8 @@ export default function Student() {
     );
   }, [awards, selectedStudentId, myGroup]);
 
+  const [showBadges, setShowBadges] = useState(false);
+
   const [signupEmail, setSignupEmail] = useState('');
   const [signupName, setSignupName] = useState('');
   const handleSelfSignup = () => {
@@ -64,6 +66,25 @@ export default function Student() {
     setSignupEmail('');
     setSignupName('');
   };
+
+  if (showBadges) {
+    return (
+      <div className="max-w-3xl mx-auto">
+        <Card title="Verdiende badges">
+          {me ? (
+            <BadgeOverview badgeDefs={BADGE_DEFS} earnedBadges={myBadges} />
+          ) : (
+            <p className="text-sm text-neutral-600">Selecteer een student om badges te bekijken.</p>
+          )}
+          <div className="mt-4">
+            <Button className="bg-indigo-600 text-white" onClick={() => setShowBadges(false)}>
+              Terug naar puntenoverzicht
+            </Button>
+          </div>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
@@ -96,7 +117,9 @@ export default function Student() {
 
       <Card title="Badges" className="lg:col-span-3">
         {me ? (
-          <BadgeOverview badgeDefs={BADGE_DEFS} earnedBadges={myBadges} />
+          <Button className="bg-indigo-600 text-white" onClick={() => setShowBadges(true)}>
+            Bekijk badges
+          </Button>
         ) : (
           <p className="text-sm text-neutral-600">Selecteer een student om badges te bekijken.</p>
         )}

--- a/src/components/BadgeOverview.js
+++ b/src/components/BadgeOverview.js
@@ -1,23 +1,15 @@
 import React from 'react';
 
 export default function BadgeOverview({ badgeDefs, earnedBadges }) {
+  const visible = badgeDefs.filter((b) => earnedBadges.includes(b.id));
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-      {badgeDefs.map((b) => {
-        const earned = earnedBadges.includes(b.id);
-        return (
-          <div key={b.id} className="flex flex-col items-center text-sm">
-            <div className="w-20 h-20 rounded-full border overflow-hidden">
-              <img
-                src={b.image}
-                alt={b.title}
-                className={`w-full h-full object-cover ${earned ? '' : 'opacity-20 grayscale'}`}
-              />
-            </div>
-            <div className="mt-2 text-center">{b.title}</div>
-          </div>
-        );
-      })}
+      {visible.map((b) => (
+        <div key={b.id} className="flex flex-col items-center text-sm">
+          <div className="badge-placeholder rounded-full border overflow-hidden"></div>
+          <div className="mt-2 text-center">{b.title}</div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -123,3 +123,17 @@ input {
     content: attr(data-label);
   }
 }
+
+/* Badge placeholder sizing */
+.badge-placeholder {
+  width: 1.5cm;
+  height: 1.5cm;
+  background: #fff;
+}
+
+@media (min-width: 768px) {
+  .badge-placeholder {
+    width: 3cm;
+    height: 3cm;
+  }
+}


### PR DESCRIPTION
## Summary
- Filter and display only earned badges with white placeholders sized responsively
- Introduce dedicated badge page with navigation back to points overview
- Add CSS utility for 1.5 cm mobile and 3 cm desktop badge placeholder sizing

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6899f64d7414832e8eb564c17a056f53