### PR TITLE
Add badge page with responsive placeholders

### DIFF
--- a/src/Student.js
+++ b/src/Student.js
@@ -50,6 +50,8 @@ export default function Student() {
     );
   }, [awards, selectedStudentId, myGroup]);
 
+  const [showBadges, setShowBadges] = useState(false);
+
   const [signupEmail, setSignupEmail] = useState('');
   const [signupName, setSignupName] = useState('');
   const handleSelfSignup = () => {
@@ -64,6 +66,25 @@ export default function Student() {
     setSignupEmail('');
     setSignupName('');
   };
+
+  if (showBadges) {
+    return (
+      <div className="max-w-3xl mx-auto">
+        <Card title="Badges">
+          {me ? (
+            <BadgeOverview badgeDefs={BADGE_DEFS} earnedBadges={myBadges} />
+          ) : (
+            <p className="text-sm text-neutral-600">Selecteer een student om badges te bekijken.</p>
+          )}
+          <div className="mt-4">
+            <Button className="bg-indigo-600 text-white" onClick={() => setShowBadges(false)}>
+              Terug naar puntenoverzicht
+            </Button>
+          </div>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
@@ -96,7 +117,9 @@ export default function Student() {
 
       <Card title="Badges" className="lg:col-span-3">
         {me ? (
-          <BadgeOverview badgeDefs={BADGE_DEFS} earnedBadges={myBadges} />
+          <Button className="bg-indigo-600 text-white" onClick={() => setShowBadges(true)}>
+            Bekijk badges
+          </Button>
         ) : (
           <p className="text-sm text-neutral-600">Selecteer een student om badges te bekijken.</p>
         )}

--- a/src/components/BadgeOverview.js
+++ b/src/components/BadgeOverview.js
@@ -7,13 +7,15 @@ export default function BadgeOverview({ badgeDefs, earnedBadges }) {
         const earned = earnedBadges.includes(b.id);
         return (
           <div key={b.id} className="flex flex-col items-center text-sm">
-            <div className="w-20 h-20 rounded-full border overflow-hidden">
+            {earned ? (
               <img
                 src={b.image}
                 alt={b.title}
-                className={`w-full h-full object-cover ${earned ? '' : 'opacity-20 grayscale'}`}
+                className="badge-box rounded-full border object-cover"
               />
-            </div>
+            ) : (
+              <div className="badge-box rounded-full border bg-white"></div>
+            )}
             <div className="mt-2 text-center">{b.title}</div>
           </div>
         );

--- a/src/index.css
+++ b/src/index.css
@@ -123,3 +123,16 @@ input {
     content: attr(data-label);
   }
 }
+
+/* Badge sizing */
+.badge-box {
+  width: 1.5cm;
+  height: 1.5cm;
+}
+
+@media (min-width: 768px) {
+  .badge-box {
+    width: 3cm;
+    height: 3cm;
+  }
+}


### PR DESCRIPTION
## Summary
- Display all badges, showing white placeholders for unearned ones and images for earned badges
- Add reusable `.badge-box` sizing class and retitle badge page to "Badges"

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6899f64d7414832e8eb564c17a056f53