### PR TITLE
Add role selection login screen and hamburger menu

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import Student from './Student';
 import { Card, Button, TextInput } from './components/ui';
 
 export default function App() {
-  const getRoute = () => (typeof location !== 'undefined' && location.hash ? location.hash.slice(1) : '/student');
+  const getRoute = () => (typeof location !== 'undefined' && location.hash ? location.hash.slice(1) : '/');
   const [route, setRoute] = useState(getRoute());
   useEffect(() => {
     const onHash = () => setRoute(getRoute());
@@ -19,24 +19,39 @@ export default function App() {
   const allowAdmin = () => { try { localStorage.setItem(ADMIN_LS, '1'); } catch {} setIsAdmin(true); };
   const denyAdmin  = () => { try { localStorage.removeItem(ADMIN_LS); } catch {} setIsAdmin(false); };
 
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 p-4 md:p-8 text-slate-800">
       <div className="max-w-6xl mx-auto">
-        <header className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-6">
+        <header className="flex items-center justify-between mb-6">
           <h1 className="text-2xl md:text-3xl font-bold">Neuromarketing Points · Prototype</h1>
-          <div className="flex gap-2 text-sm">
-            <a href="#/student" className={`px-3 py-2 rounded-xl border ${route === '/student' ? 'bg-indigo-100' : 'bg-white'}`}>Studenten</a>
-            <a href="#/admin"   className={`px-3 py-2 rounded-xl border ${route === '/admin'   ? 'bg-indigo-100' : 'bg-white'}`}>Beheer</a>
-            {route === '/admin' && isAdmin && (
-              <button className="px-3 py-2 rounded-xl border" onClick={denyAdmin}>Uitloggen</button>
-            )}
-          </div>
+          {route !== '/' && (
+            <div style={{ position: 'relative' }}>
+              <button
+                onClick={() => setMenuOpen(!menuOpen)}
+                style={{ background: 'none', border: 'none', fontSize: '24px', cursor: 'pointer' }}
+                aria-label="Menu"
+              >☰</button>
+              {menuOpen && (
+                <div style={{ position: 'absolute', right: 0, marginTop: '8px', background: '#fff', border: '1px solid #ccc', borderRadius: '4px', boxShadow: '0 2px 6px rgba(0,0,0,0.15)' }}>
+                  <a href="#/student" style={{ display: 'block', padding: '8px 12px', textDecoration: 'none', color: '#000' }} onClick={() => setMenuOpen(false)}>Student</a>
+                  <a href="#/admin" style={{ display: 'block', padding: '8px 12px', textDecoration: 'none', color: '#000' }} onClick={() => setMenuOpen(false)}>Beheer</a>
+                  {route === '/admin' && isAdmin && (
+                    <button onClick={() => { denyAdmin(); setMenuOpen(false); }} style={{ display: 'block', width: '100%', padding: '8px 12px', background: 'none', border: 'none', textAlign: 'left', cursor: 'pointer' }}>Uitloggen</button>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
         </header>
 
         {route === '/admin' ? (
           isAdmin ? <Admin /> : <AdminGate onAllow={allowAdmin} />
-        ) : (
+        ) : route === '/student' ? (
           <Student />
+        ) : (
+          <RoleSelect />
         )}
       </div>
     </div>
@@ -66,6 +81,23 @@ function AdminGate({ onAllow }) {
         <div className="mt-3 flex gap-2">
           <Button className="bg-indigo-600 text-white" onClick={submit}>Inloggen</Button>
           <a href="#/student" className="px-4 py-2 rounded-2xl border">Terug naar studenten</a>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function RoleSelect() {
+  return (
+    <div className="max-w-md mx-auto">
+      <Card title="Wie ben je?">
+        <div className="flex flex-col gap-4">
+          <a href="#/student" className="w-full">
+            <Button className="w-full bg-indigo-600 text-white">Ik ben student</Button>
+          </a>
+          <a href="#/admin" className="w-full">
+            <Button className="w-full bg-indigo-600 text-white">Ik ben docent</Button>
+          </a>
         </div>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- add initial role selection screen for student or teacher login
- add hamburger menu to switch between student and admin and log out

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689a08ccb77c832e8f82db1c41f4f547