### PR TITLE
Add admin-only scores page and update branding

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>House of Neuro</title>
+  <title>Neuromarketing Housepoints</title>
   <link rel="stylesheet" href="%PUBLIC_URL%/style.css" />
 </head>
 <body>

--- a/public/style.css
+++ b/public/style.css
@@ -1,5 +1,5 @@
 /* ===========================
-   Neuromarketing Points UI
+   Neuromarketing Housepoints UI
    Style: "Brain Buddy" (matches badge art)
    =========================== */
 
@@ -127,7 +127,7 @@ body{
   box-shadow: inset 0 -2px 0 rgba(0,0,0,.2);
 }
 
-/* ---------- Points counter ---------- */
+/* ---------- Housepoints counter ---------- */
 .points{
   display:flex; align-items:center; gap:10px;
   padding:10px 14px;

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -120,6 +120,11 @@ export default function Admin() {
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+      <Card title="Scores" className="lg:col-span-3">
+        <a href="#/roster">
+          <Button className="bg-indigo-600 text-white">Bekijk alle scores</Button>
+        </a>
+      </Card>
       <Card title="Student toevoegen">
         <div className="grid grid-cols-1 gap-2">
           <TextInput value={newStudent} onChange={setNewStudent} placeholder="Naam" />

--- a/src/AdminRoster.js
+++ b/src/AdminRoster.js
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { Card } from './components/ui';
 import useStudents from './hooks/useStudents';
 import useGroups from './hooks/useGroups';
+import { getIndividualLeaderboard } from './utils';
 
 export default function AdminRoster() {
   const [students] = useStudents();
@@ -11,17 +12,31 @@ export default function AdminRoster() {
     for (const g of groups) m.set(g.id, g);
     return m;
   }, [groups]);
+  const leaderboard = useMemo(() => getIndividualLeaderboard(students), [students]);
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <Card title="Studenten">
-        <ul className="list-disc pl-5">
-          {students.map((s) => (
-            <li key={s.id}>
-              {s.name} {s.groupId ? `(${groupById.get(s.groupId)?.name || '-'})` : '(geen groep)'}
-            </li>
-          ))}
-        </ul>
+      <Card title="Scores – Studenten" className="md:col-span-2">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left border-b">
+              <th className="py-1 pr-2">#</th>
+              <th className="py-1 pr-2">Student</th>
+              <th className="py-1 pr-2">Groep</th>
+              <th className="py-1 pr-2 text-right">Punten</th>
+            </tr>
+          </thead>
+          <tbody>
+            {leaderboard.map((row) => (
+              <tr key={row.id} className="border-b last:border-0">
+                <td className="py-1 pr-2">{row.rank}</td>
+                <td className="py-1 pr-2">{row.name}</td>
+                <td className="py-1 pr-2">{row.groupId ? groupById.get(row.groupId)?.name || '-' : '-'}</td>
+                <td className={`py-1 pr-2 text-right font-semibold ${row.points > 0 ? 'text-emerald-700' : row.points < 0 ? 'text-rose-700' : 'text-neutral-700'}`}>{row.points}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </Card>
       <Card title="Groepen">
         <ul className="list-disc pl-5">

--- a/src/App.js
+++ b/src/App.js
@@ -26,7 +26,7 @@ export default function App() {
     <div className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 p-4 md:p-8 text-slate-800">
       <div className="max-w-6xl mx-auto">
         <header style={{ position: 'relative', marginBottom: '1.5rem' }}>
-          <h1 style={{ fontSize: '24px', fontWeight: 'bold', textAlign: 'center' }}>Neuromarketing Points · Prototype</h1>
+          <h1 style={{ fontSize: '24px', fontWeight: 'bold', textAlign: 'center' }}>Neuromarketing Housepoints</h1>
           {route !== '/' && (
             <div style={{ position: 'absolute', top: 0, right: 0 }}>
               <button
@@ -38,7 +38,6 @@ export default function App() {
                 <div style={{ position: 'absolute', top: '100%', right: 0, marginTop: '8px', background: '#fff', border: '1px solid #ccc', borderRadius: '4px', boxShadow: '0 2px 6px rgba(0,0,0,0.15)' }}>
                   <a href="#/student" style={{ display: 'block', padding: '8px 12px', textDecoration: 'none', color: '#000' }} onClick={() => setMenuOpen(false)}>Student</a>
                   <a href="#/admin" style={{ display: 'block', padding: '8px 12px', textDecoration: 'none', color: '#000' }} onClick={() => setMenuOpen(false)}>Beheer</a>
-                  {isAdmin && <a href="#/roster" style={{ display: 'block', padding: '8px 12px', textDecoration: 'none', color: '#000' }} onClick={() => setMenuOpen(false)}>Overzicht</a>}
                   {isAdmin && (
                     <button onClick={() => { denyAdmin(); setMenuOpen(false); }} style={{ display: 'block', width: '100%', padding: '8px 12px', background: 'none', border: 'none', textAlign: 'left', cursor: 'pointer' }}>Uitloggen</button>
                   )}

--- a/src/components/BadgeOverview.js
+++ b/src/components/BadgeOverview.js
@@ -3,7 +3,7 @@ import React from 'react';
 export default function BadgeOverview({ badgeDefs, earnedBadges }) {
   const visible = badgeDefs.filter((b) => earnedBadges.includes(b.id));
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 p-4">
 
       {badgeDefs.map((b) => {
         const earned = earnedBadges.includes(b.id);

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-/* Global styles for the House of Neuro app.  These styles are
+/* Global styles for the Neuromarketing Housepoints app.  These styles are
    intentionally simple and mobile-friendly. */
 body {
   margin: 0;


### PR DESCRIPTION
## Summary
- Rebrand app to "Neuromarketing Housepoints" including header and HTML title
- Add admin-only score overview page accessible via button on admin screen
- Improve badge layout with additional padding

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689a2af6c4ec832ea2f114fb6477940a