### PR TITLE
Integrate Tailwind and clean UI components

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1"
+    "react-scripts": "5.0.1",
+    "tailwindcss": "^4.1.11"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.js
+++ b/src/App.js
@@ -25,21 +25,21 @@ export default function App() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 p-4 md:p-8 text-slate-800">
       <div className="max-w-6xl mx-auto">
-        <header style={{ position: 'relative', marginBottom: '1.5rem' }}>
-          <h1 style={{ fontSize: '24px', fontWeight: 'bold', textAlign: 'center' }}>Neuromarketing Housepoints</h1>
+        <header className="app-header">
+          <h1 className="app-title">Neuromarketing Housepoints</h1>
           {route !== '/' && (
-            <div style={{ position: 'absolute', top: 0, right: 0 }}>
+            <div className="menu-wrapper">
               <button
                 onClick={() => setMenuOpen(!menuOpen)}
-                style={{ background: 'none', border: 'none', fontSize: '24px', cursor: 'pointer' }}
+                className="menu-button"
                 aria-label="Menu"
               >☰</button>
               {menuOpen && (
-                <div style={{ position: 'absolute', top: '100%', right: 0, marginTop: '8px', background: '#fff', border: '1px solid #ccc', borderRadius: '4px', boxShadow: '0 2px 6px rgba(0,0,0,0.15)' }}>
-                  <a href="#/student" style={{ display: 'block', padding: '8px 12px', textDecoration: 'none', color: '#000' }} onClick={() => setMenuOpen(false)}>Student</a>
-                  <a href="#/admin" style={{ display: 'block', padding: '8px 12px', textDecoration: 'none', color: '#000' }} onClick={() => setMenuOpen(false)}>Beheer</a>
+                <div className="dropdown">
+                  <a href="#/student" className="dropdown-link" onClick={() => setMenuOpen(false)}>Student</a>
+                  <a href="#/admin" className="dropdown-link" onClick={() => setMenuOpen(false)}>Beheer</a>
                   {isAdmin && (
-                    <button onClick={() => { denyAdmin(); setMenuOpen(false); }} style={{ display: 'block', width: '100%', padding: '8px 12px', background: 'none', border: 'none', textAlign: 'left', cursor: 'pointer' }}>Uitloggen</button>
+                    <button onClick={() => { denyAdmin(); setMenuOpen(false); }} className="dropdown-button">Uitloggen</button>
                   )}
                 </div>
               )}

--- a/src/components/BadgeOverview.js
+++ b/src/components/BadgeOverview.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
 export default function BadgeOverview({ badgeDefs, earnedBadges }) {
-  const visible = badgeDefs.filter((b) => earnedBadges.includes(b.id));
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 p-4">
 
@@ -22,13 +21,6 @@ export default function BadgeOverview({ badgeDefs, earnedBadges }) {
           </div>
         );
       })}
-
-      {visible.map((b) => (
-        <div key={b.id} className="flex flex-col items-center text-sm">
-          <div className="badge-placeholder rounded-full border overflow-hidden"></div>
-          <div className="mt-2 text-center">{b.title}</div>
-        </div>
-      ))}
 
     </div>
   );

--- a/src/components/ui.js
+++ b/src/components/ui.js
@@ -15,7 +15,7 @@ export function Button({ children, onClick, type = 'button', className = '', dis
       type={type}
       onClick={onClick}
       disabled={disabled}
-      className={`rounded-2xl shadow px-4 py-2 hover:opacity-90 active:scale-[0.99] transition border border-neutral-200 ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`}
+      className={`rounded-2xl shadow px-4 py-2 hover:opacity-90 active:scale-[0.99] transition border border-neutral-200 focus:outline-none focus:ring-2 focus:ring-indigo-400 ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`}
     >
       {children}
     </button>

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,8 @@
-/* Global styles for the Neuromarketing Housepoints app.  These styles are
-   intentionally simple and mobile-friendly. */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Global styles for the Neuromarketing Housepoints app. These styles are intentionally simple and mobile-friendly. */
 body {
   margin: 0;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
@@ -124,31 +127,69 @@ input {
   }
 }
 
-
 /* Badge sizing */
 .badge-box {
-  width: 1.5cm;
-  height: 1.5cm;
+  width: 3rem;
+  height: 3rem;
 }
 
 @media (min-width: 768px) {
   .badge-box {
-    width: 3cm;
-    height: 3cm;
+    width: 6rem;
+    height: 6rem;
   }
 }
 
-
-/* Badge sizing */
-.badge-box {
-  width: 1.5cm;
-  height: 1.5cm;
+/* Header/menu styles */
+.app-header {
+  position: relative;
+  margin-bottom: 1.5rem;
 }
 
-@media (min-width: 768px) {
-  .badge-box {
+.app-title {
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+}
 
-    width: 3cm;
-    height: 3cm;
-  }
+.menu-wrapper {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.menu-button {
+  background: none;
+  border: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 8px;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+}
+
+.dropdown-link,
+.dropdown-button {
+  display: block;
+  padding: 8px 12px;
+  text-decoration: none;
+  color: #000;
+}
+
+.dropdown-button {
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./src/**/*.js"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Tailwind setup with PostCSS and convert global styles
- fix duplicate badge rendering and streamline badge sizing
- move header/menu inline styles to CSS classes and improve button focus

## Testing
- `npm test -- --watchAll=false`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689a2b1764a0832e8e19327519650154