### PR TITLE
style: improve mobile menu

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -223,15 +223,16 @@ select:focus {
 
 .menu-wrapper {
   position: absolute;
-  top: 0;
-  right: 0;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 50;
 }
 
 .menu-button {
   background: none;
   border: none;
-  padding: 0;
-  border-radius: 0;
+  padding: 0.5rem;
+  border-radius: 8px;
   font-size: 24px;
   cursor: pointer;
 }
@@ -240,17 +241,20 @@ select:focus {
   position: absolute;
   top: 100%;
   right: 0;
-  margin-top: 8px;
+  margin-top: 0.5rem;
   background: #fff;
   border: 1px solid #ccc;
-  border-radius: 4px;
+  border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  z-index: 50;
+  min-width: 160px;
+  padding: 0.25rem 0;
 }
 
 .dropdown-link,
 .dropdown-button {
   display: block;
-  padding: 8px 12px;
+  padding: 0.75rem 1rem;
   text-decoration: none;
   color: #000;
 }


### PR DESCRIPTION
## Summary
- Ensure hamburger dropdown overlays other content and adds spacing from screen edges
- Expand mobile dropdown hit targets for easier tapping

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689a3639c84c832ea9f03a7a3061bc56