### PR TITLE
Refine UI styling and adjust image sizing

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -75,6 +75,12 @@ body{
   -webkit-font-smoothing:antialiased;  text-rendering:optimizeLegibility;
 }
 
+img{
+  max-width:100%;
+  height:auto;
+  display:block;
+}
+
 /* Utility */
 .rounded{border-radius:var(--r-lg)}
 .shadow{box-shadow:var(--shadow-md)}

--- a/src/index.css
+++ b/src/index.css
@@ -3,10 +3,10 @@
 @tailwind utilities;
 /* iOS-inspired global styles */
 :root {
-  --color-bg: #F2F2F7;
+  --color-bg: #F5F5F7;
   --color-bg-card: #FFFFFF;
   --color-text: #1C1C1E;
-  --color-accent: #0A84FF;
+  --color-accent: #007AFF;
   --space: 1rem;
   --radius: 12px;
   --shadow: 0 4px 12px rgba(0, 0, 0, 0.07);
@@ -14,10 +14,16 @@
 
 body {
   margin: 0;
-  font-family: 'SF Pro', system-ui, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro', system-ui, sans-serif;
   background: var(--color-bg);
   color: var(--color-text);
   line-height: 1.5;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
 }
 
 .card {
@@ -33,14 +39,15 @@ body {
   color: #fff;
   border: none;
   border-radius: var(--radius);
-  padding: var(--space) calc(var(--space) * 1.5);
+  padding: var(--space) calc(var(--space) * 2);
+  min-height: 44px;
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
   transition: background 0.2s, transform 0.2s;
 }
 .button:hover {
-  background: #0C77DF;
+  background: #0063CE;
 }
 .button:active {
   transform: scale(0.98);
@@ -198,14 +205,14 @@ select:focus {
 
 /* Badge sizing */
 .badge-box {
-  width: 3rem;
-  height: 3rem;
+  width: 2.5rem;
+  height: 2.5rem;
 }
 
 @media (min-width: 768px) {
   .badge-box {
-    width: 6rem;
-    height: 6rem;
+    width: 5rem;
+    height: 5rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- polish global styles with Apple-inspired colors and fonts
- ensure images scale responsively and buttons meet touch target size
- tone down badge dimensions so artwork isn't oversized

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689a3a41e0f0832e82467696e21e79e7