### PR TITLE
feat: externalize points data

### DIFF
--- a/src/data/awards.json
+++ b/src/data/awards.json
@@ -1,0 +1,4 @@
+[
+  { "id": "a1", "ts": 1754980224218, "type": "group",   "targetId": "g1", "amount": 10, "reason": "Kick-off pitch" },
+  { "id": "a2", "ts": 1754980824218, "type": "student", "targetId": "s3", "amount": 4,  "reason": "Reading quiz" }
+]

--- a/src/data/groups.json
+++ b/src/data/groups.json
@@ -1,0 +1,4 @@
+[
+  { "id": "g1", "name": "Team EEG",       "points": 20 },
+  { "id": "g2", "name": "Team Eye-Track", "points": 8 }
+]

--- a/src/data/students.json
+++ b/src/data/students.json
@@ -1,0 +1,5 @@
+[
+  { "id": "s1", "name": "Alex",  "email": "alex@student.nhlstenden.com",  "groupId": "g1", "points": 10, "badges": [] },
+  { "id": "s2", "name": "Bo",    "email": "bo@student.nhlstenden.com",    "groupId": "g1", "points": 5,  "badges": [] },
+  { "id": "s3", "name": "Casey", "email": "casey@student.nhlstenden.com", "groupId": "g2", "points": 12, "badges": [] }
+]

--- a/src/hooks/useAwards.js
+++ b/src/hooks/useAwards.js
@@ -1,10 +1,7 @@
 import usePersistentState from './usePersistentState';
+import seedAwards from '../data/awards.json';
 
 const LS_KEY = 'nm_points_awards_v2';
-const seedAwards = [
-  { id: 'a1', ts: Date.now() - 1000 * 60 * 60, type: 'group',   targetId: 'g1', amount: 10, reason: 'Kick-off pitch' },
-  { id: 'a2', ts: Date.now() - 1000 * 60 * 50, type: 'student', targetId: 's3', amount: 4,  reason: 'Reading quiz'   },
-];
 
 export default function useAwards() {
   return usePersistentState(LS_KEY, seedAwards);

--- a/src/hooks/useGroups.js
+++ b/src/hooks/useGroups.js
@@ -1,10 +1,7 @@
 import usePersistentState from './usePersistentState';
+import seedGroups from '../data/groups.json';
 
 const LS_KEY = 'nm_points_groups_v2';
-const seedGroups = [
-  { id: 'g1', name: 'Team EEG',       points: 20 },
-  { id: 'g2', name: 'Team Eye-Track', points: 8  },
-];
 
 export default function useGroups() {
   return usePersistentState(LS_KEY, seedGroups);

--- a/src/hooks/useStudents.js
+++ b/src/hooks/useStudents.js
@@ -1,11 +1,7 @@
 import usePersistentState from './usePersistentState';
+import seedStudents from '../data/students.json';
 
 const LS_KEY = 'nm_points_students_v2';
-const seedStudents = [
-  { id: 's1', name: 'Alex',  email: 'alex@student.nhlstenden.com',  groupId: 'g1', points: 10, badges: [] },
-  { id: 's2', name: 'Bo',    email: 'bo@student.nhlstenden.com',    groupId: 'g1', points: 5,  badges: [] },
-  { id: 's3', name: 'Casey', email: 'casey@student.nhlstenden.com', groupId: 'g2', points: 12, badges: [] },
-];
 
 export default function useStudents() {
   return usePersistentState(LS_KEY, seedStudents);


### PR DESCRIPTION
## Summary
- move initial groups, students, and awards into JSON files
- load point data from external JSON files to ease updates

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689aecf43f6c832eb1984db6da3b8b11