### PR TITLE
Constrain student select width on badge assignment page

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -205,7 +205,7 @@ export default function Admin() {
       {page === 'badges' && (
         <Card title="Badges toekennen">
           <div className="grid grid-cols-1 gap-2">
-            <Select value={badgeStudentId} onChange={setBadgeStudentId}>
+            <Select value={badgeStudentId} onChange={setBadgeStudentId} className="max-w-xs">
               <option value="">Kies student…</option>
               {students.map((s) => (
                 <option key={s.id} value={s.id}>


### PR DESCRIPTION
## Summary
- limit student dropdown to a reasonable width on badges page

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689aefd13b18832ebc392548a988caf8