### PR TITLE
Display student emails in group assignment overview

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -213,6 +213,7 @@ export default function Admin() {
               <thead>
                 <tr className="text-left border-b">
                   <th className="py-1 pr-2">Student</th>
+                  <th className="py-1 pr-2">E-mail</th>
                   <th className="py-1 pr-2">Groep</th>
                 </tr>
               </thead>
@@ -220,6 +221,7 @@ export default function Admin() {
                 {students.map((s) => (
                   <tr key={s.id} className="border-b last:border-0">
                     <td className="py-1 pr-2">{s.name}</td>
+                    <td className="py-1 pr-2">{s.email || '-'}</td>
                     <td className="py-1 pr-2">{s.groupId ? groupById.get(s.groupId)?.name || '-' : '-'}</td>
                   </tr>
                 ))}


### PR DESCRIPTION
## Summary
- Show each student's email address alongside their group in the group-assignment overview

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689afe852120832ebfa417b0e94d3fee