### PR TITLE
Optimize badge sizing for mobile

### DIFF
--- a/src/components/BadgeOverview.js
+++ b/src/components/BadgeOverview.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function BadgeOverview({ badgeDefs, earnedBadges }) {
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 p-4">
+    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-4 p-4">
 
       {badgeDefs.map((b) => {
         const earned = earnedBadges.includes(b.id);

--- a/src/index.css
+++ b/src/index.css
@@ -205,14 +205,14 @@ select:focus {
 
 /* Badge sizing */
 .badge-box {
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 1.5cm;
+  height: 1.5cm;
 }
 
 @media (min-width: 768px) {
   .badge-box {
-    width: 5rem;
-    height: 5rem;
+    width: 3cm;
+    height: 3cm;
   }
 }
 


### PR DESCRIPTION
## Summary
- Set badge dimensions to 1.5cm on mobile and 3cm on larger screens
- Show three badge columns on mobile, expanding for larger viewports

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689b106b6e78832e94c20ca485b25602