### PR TITLE
Improve leaderboard layout and streamline student login

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -218,6 +218,7 @@ img{
   padding:10px 12px; border-radius:var(--r-lg);
   background:linear-gradient(180deg, var(--white), var(--surface));
   box-shadow:var(--shadow-sm);
+  white-space:nowrap;
 }
 .leaderboard__rank{
   width:34px;height:34px;border-radius:50%;
@@ -226,7 +227,7 @@ img{
   color:#3b2b00; font-weight:900;
   box-shadow:inset 0 2px 6px rgba(255,255,255,.6);
 }
-.leaderboard__name{ flex:1; font-weight:800 }
+.leaderboard__name{ flex:1; font-weight:800; overflow:hidden; text-overflow:ellipsis }
 .leaderboard__score{ font-family:var(--font-num); font-weight:900 }
 
 /* ---------- Speech bubble (for onboarding / “welkom”) ---------- */

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -347,7 +347,7 @@ export default function Admin() {
 
       {page === 'leaderboard-students' && (
         <Card title="Leaderboard – Individueel">
-          <table className="w-full text-sm">
+          <table className="w-full text-sm whitespace-nowrap">
             <thead>
               <tr className="text-left border-b">
                 <th className="py-1 pr-2">#</th>
@@ -376,7 +376,7 @@ export default function Admin() {
 
       {page === 'leaderboard-groups' && (
         <Card title="Leaderboard – Groepen">
-          <table className="w-full text-sm">
+          <table className="w-full text-sm whitespace-nowrap">
             <thead>
               <tr className="text-left border-b">
                 <th className="py-1 pr-2">#</th>

--- a/src/AdminRoster.js
+++ b/src/AdminRoster.js
@@ -17,7 +17,7 @@ export default function AdminRoster() {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
       <Card title="Scores – Studenten" className="md:col-span-2">
-        <table className="w-full text-sm">
+        <table className="w-full text-sm whitespace-nowrap">
           <thead>
             <tr className="text-left border-b">
               <th className="py-1 pr-2">#</th>

--- a/src/Student.js
+++ b/src/Student.js
@@ -51,6 +51,8 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
 
   const [showBadges, setShowBadges] = useState(false);
 
+  const [authMode, setAuthMode] = useState('login');
+
   const [loginEmail, setLoginEmail] = useState('');
   const [loginError, setLoginError] = useState('');
   const handleLogin = () => {
@@ -67,7 +69,6 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
   };
 
   const [signupEmail, setSignupEmail] = useState('');
-
   const [signupName, setSignupName] = useState('');
   const [signupError, setSignupError] = useState('');
   const handleSignup = () => {
@@ -85,80 +86,74 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
       setSignupError('');
     }
   };
-
-  const handleSelfSignup = () => {
-    if (!signupEmail.trim() || !emailValid(signupEmail)) return;
-
-    const normEmail = signupEmail.trim().toLowerCase();
-    const existing = students.find((s) => (s.email || '').toLowerCase() === normEmail);
-    if (existing) {
-      setSignupError('E-mailadres bestaat al.');
-    } else {
-      const derivedName = nameFromEmail(normEmail);
-      const newId = addStudent(derivedName, normEmail);
-      setSelectedStudentId(newId);
-      setSignupName('');
-      setSignupError('');
-    }
-
-    setSignupEmail('');
-  };
   
   if (!selectedStudentId) {
     return (
       <div className="max-w-md mx-auto">
-        <Card title="Log in of account aanmaken">
-
-            <div className="grid grid-cols-1 gap-6">
-              <div>
-              <h2 className="font-semibold mb-2">Bestaand account</h2>
+        {authMode === 'login' ? (
+          <Card title="Log in">
+            <div className="grid grid-cols-1 gap-4">
               <TextInput value={loginEmail} onChange={setLoginEmail} placeholder="E-mail (@student.nhlstenden.com)" />
               {loginEmail && !emailValid(loginEmail) && (
                 <div className="text-sm text-rose-600">Alleen adressen eindigend op @student.nhlstenden.com zijn toegestaan.</div>
               )}
               {loginError && <div className="text-sm text-rose-600">{loginError}</div>}
               <Button
-                className="mt-2 bg-indigo-600 text-white"
+                className="bg-indigo-600 text-white"
                 disabled={!loginEmail.trim() || !emailValid(loginEmail)}
                 onClick={handleLogin}
               >
                 Log in
               </Button>
+              <button
+                className="text-sm text-indigo-600 text-left"
+                onClick={() => {
+                  setSignupEmail('');
+                  setSignupName('');
+                  setSignupError('');
+                  setAuthMode('signup');
+                }}
+              >
+                Account aanmaken
+              </button>
             </div>
-            <div className="border-t pt-4">
-              <h2 className="font-semibold mb-2">Nieuw account</h2>
-              <TextInput value={signupEmail} onChange={setSignupEmail} placeholder="E-mail (@student.nhlstenden.com)" />
+          </Card>
+        ) : (
+          <Card title="Account aanmaken">
+            <div className="grid grid-cols-1 gap-4">
+              <TextInput
+                value={signupEmail}
+                onChange={(v) => {
+                  setSignupEmail(v);
+                  setSignupName(nameFromEmail(v));
+                }}
+                placeholder="E-mail (@student.nhlstenden.com)"
+              />
               {signupEmail && !emailValid(signupEmail) && (
                 <div className="text-sm text-rose-600">Alleen adressen eindigend op @student.nhlstenden.com zijn toegestaan.</div>
               )}
               <TextInput value={signupName} onChange={setSignupName} placeholder="Volledige naam" />
               {signupError && <div className="text-sm text-rose-600">{signupError}</div>}
-                <Button
-                  className="mt-2 bg-indigo-600 text-white"
-                  disabled={!signupEmail.trim() || !signupName.trim() || !emailValid(signupEmail)}
-                  onClick={handleSignup}
-                >
-                  Account aanmaken
-                </Button>
-              </div>
-
-            </div>
-
-            <div className="grid grid-cols-1 gap-2">
-              <TextInput value={signupEmail} onChange={setSignupEmail} placeholder="E-mail (@student.nhlstenden.com)" />
-              {signupEmail && !emailValid(signupEmail) && (
-                <div className="text-sm text-rose-600">Alleen adressen eindigend op @student.nhlstenden.com zijn toegestaan.</div>
-              )}
               <Button
-              className="bg-indigo-600 text-white"
-              disabled={!signupEmail.trim() || !emailValid(signupEmail)}
-              onClick={handleSelfSignup}
-            >
-              Log in / Maak account
-            </Button>
-
-          </div>
-        </Card>
+                className="bg-indigo-600 text-white"
+                disabled={!signupEmail.trim() || !signupName.trim() || !emailValid(signupEmail)}
+                onClick={handleSignup}
+              >
+                Account aanmaken
+              </Button>
+              <button
+                className="text-sm text-indigo-600 text-left"
+                onClick={() => {
+                  setLoginEmail('');
+                  setLoginError('');
+                  setAuthMode('login');
+                }}
+              >
+                Terug naar inloggen
+              </button>
+            </div>
+          </Card>
+        )}
       </div>
     );
   }
@@ -210,7 +205,7 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
       </Card>
 
       <Card title="Leaderboard – Individueel" className="lg:col-span-2">
-        <table className="w-full text-sm">
+        <table className="w-full text-sm whitespace-nowrap">
           <thead>
             <tr className="text-left border-b">
               <th className="py-1 pr-2">#</th>
@@ -250,7 +245,7 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
       </Card>
 
       <Card title="Leaderboard – Groepen" className="lg:col-span-3">
-        <table className="w-full text-sm">
+        <table className="w-full text-sm whitespace-nowrap">
           <thead>
             <tr className="text-left border-b">
               <th className="py-1 pr-2">#</th>


### PR DESCRIPTION
## Summary
- Prevent leaderboard rows from wrapping and keep entries on a single line
- Simplify student login with separate pages for login and account creation, auto-filling name from email

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689b26066c00832e8bfc017b32d2327f