### PR TITLE
Improve login UI and badge view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,6 @@ import Admin from './Admin';
 import Student from './Student';
 import AdminRoster from './AdminRoster';
 import { Card, Button, TextInput } from './components/ui';
-import useStudents from './hooks/useStudents';
 import usePersistentState from './hooks/usePersistentState';
 
 export default function App() {
@@ -22,18 +21,9 @@ export default function App() {
   const allowAdmin = () => { try { localStorage.setItem(ADMIN_LS, '1'); } catch {} setIsAdmin(true); };
   const denyAdmin  = () => { try { localStorage.removeItem(ADMIN_LS); } catch {} setIsAdmin(false); };
 
-  const [students] = useStudents();
   const [selectedStudentId, setSelectedStudentId] = usePersistentState('nm_points_current_student', '');
-  const me = students.find((s) => s.id === selectedStudentId) || null;
 
   const [menuOpen, setMenuOpen] = useState(false);
-
-  const logoutStudent = () => {
-    try { localStorage.removeItem('nm_points_current_student'); } catch {}
-    setSelectedStudentId('');
-    setMenuOpen(false);
-    window.location.hash = '/';
-  };
 
   const logoutAdmin = () => {
     denyAdmin();
@@ -57,9 +47,6 @@ export default function App() {
                 <div className="dropdown">
                   <a href="#/student" className="dropdown-link" onClick={() => setMenuOpen(false)}>Student</a>
                   <a href="#/admin" className="dropdown-link" onClick={() => setMenuOpen(false)}>Beheer</a>
-                  {me && (
-                    <button onClick={logoutStudent} className="dropdown-button">Uitloggen student</button>
-                  )}
                   {isAdmin && (
                     <button onClick={logoutAdmin} className="dropdown-button">Uitloggen beheer</button>
                   )}
@@ -68,10 +55,6 @@ export default function App() {
             </div>
           )}
         </header>
-
-        {route === '/student' && me && (
-          <div className="text-center mb-4">Ingelogd als {me.name}</div>
-        )}
 
         {route === '/admin' ? (
           isAdmin ? <Admin /> : <AdminGate onAllow={allowAdmin} />
@@ -121,10 +104,10 @@ function RoleSelect() {
     <div className="max-w-md mx-auto">
       <Card title="Wie ben je?">
         <div className="flex flex-col gap-4">
-          <a href="#/student" className="w-full">
+          <a href="#/student" className="block w-full">
             <Button className="w-full bg-indigo-600 text-white">Ik ben student</Button>
           </a>
-          <a href="#/admin" className="w-full">
+          <a href="#/admin" className="block w-full">
             <Button className="w-full bg-indigo-600 text-white">Ik ben docent</Button>
           </a>
         </div>

--- a/src/Student.js
+++ b/src/Student.js
@@ -53,6 +53,11 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
 
   const [authMode, setAuthMode] = useState('login');
 
+  const handleLogout = () => {
+    setSelectedStudentId('');
+    window.location.hash = '/';
+  };
+
   const [loginEmail, setLoginEmail] = useState('');
   const [loginError, setLoginError] = useState('');
   const handleLogin = () => {
@@ -161,36 +166,50 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
   if (showBadges) {
     return (
       <div className="max-w-3xl mx-auto">
+        {me && (
+          <div className="flex items-center justify-between mb-4">
+            <span>Ingelogd als {me.name}</span>
+            <Button className="bg-indigo-600 text-white" onClick={handleLogout}>Uitloggen</Button>
+          </div>
+        )}
         <Card title="Verdiende badges">
-
           {me ? (
-            <BadgeOverview badgeDefs={BADGE_DEFS} earnedBadges={myBadges} />
+            <>
+              <div className="sticky top-0 bg-white pb-4 z-10">
+                <Button className="bg-indigo-600 text-white" onClick={() => setShowBadges(false)}>
+                  Terug naar puntenoverzicht
+                </Button>
+              </div>
+              <BadgeOverview badgeDefs={BADGE_DEFS} earnedBadges={myBadges} />
+            </>
           ) : (
             <p className="text-sm text-neutral-600">Selecteer een student om badges te bekijken.</p>
           )}
-          <div className="mt-4">
-            <Button className="bg-indigo-600 text-white" onClick={() => setShowBadges(false)}>
-              Terug naar puntenoverzicht
-            </Button>
-          </div>
         </Card>
       </div>
     );
   }
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
-      <Card title="Badges" className="lg:col-span-3">
-        {me ? (
-          <Button className="bg-indigo-600 text-white" onClick={() => setShowBadges(true)}>
-            Bekijk badges
-          </Button>
-        ) : (
-          <p className="text-sm text-neutral-600">Selecteer een student om badges te bekijken.</p>
-        )}
-      </Card>
+    <div>
+      {me && (
+        <div className="flex items-center justify-between mb-4">
+          <span>Ingelogd als {me.name}</span>
+          <Button className="bg-indigo-600 text-white" onClick={handleLogout}>Uitloggen</Button>
+        </div>
+      )}
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
+        <Card title="Badges" className="lg:col-span-3">
+          {me ? (
+            <Button className="bg-indigo-600 text-white" onClick={() => setShowBadges(true)}>
+              Bekijk badges
+            </Button>
+          ) : (
+            <p className="text-sm text-neutral-600">Selecteer een student om badges te bekijken.</p>
+          )}
+        </Card>
 
-      <Card title="Jouw recente activiteiten" className="lg:col-span-2 max-h-[320px] overflow-auto">
+        <Card title="Jouw recente activiteiten" className="lg:col-span-2 max-h-[320px] overflow-auto">
         <ul className="space-y-2 text-sm">
           {myAwards.length === 0 && <li>Geen recente items.</li>}
           {myAwards.map((a) => (
@@ -202,9 +221,9 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
             </li>
           ))}
         </ul>
-      </Card>
+        </Card>
 
-      <Card title="Leaderboard – Individueel" className="lg:col-span-2">
+        <Card title="Leaderboard – Individueel" className="lg:col-span-2">
         <table className="w-full text-sm whitespace-nowrap">
           <thead>
             <tr className="text-left border-b">
@@ -242,9 +261,9 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
             })()}
           </tbody>
         </table>
-      </Card>
+        </Card>
 
-      <Card title="Leaderboard – Groepen" className="lg:col-span-3">
+        <Card title="Leaderboard – Groepen" className="lg:col-span-3">
         <table className="w-full text-sm whitespace-nowrap">
           <thead>
             <tr className="text-left border-b">
@@ -263,7 +282,8 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
             ))}
           </tbody>
         </table>
-      </Card>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -205,14 +205,14 @@ select:focus {
 
 /* Badge sizing */
 .badge-box {
-  width: 1.5cm;
-  height: 1.5cm;
+  width: 2.5cm;
+  height: 2.5cm;
 }
 
 @media (min-width: 768px) {
   .badge-box {
-    width: 3cm;
-    height: 3cm;
+    width: 4cm;
+    height: 4cm;
   }
 }
 


### PR DESCRIPTION
## Summary
- show logged-in student's name and logout button on student pages
- keep badge overview's return button sticky at the top
- enlarge badge icons and fix spacing on login screen

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689b35fd6628832e86c6eb35d581b570