### PR TITLE
fix: resolve tailwind postcss plugin error

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     ]
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.12",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- install new Tailwind PostCSS plugin
- configure PostCSS to use `@tailwindcss/postcss`

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68ab5c77e930832e8b445f8256c1bd37