### PR TITLE
feat: stack and expand badges

### DIFF
--- a/src/components/BadgeOverview.js
+++ b/src/components/BadgeOverview.js
@@ -1,27 +1,44 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 export default function BadgeOverview({ badgeDefs, earnedBadges }) {
+  const [expanded, setExpanded] = useState(null);
+
+  const expandedBadge = badgeDefs.find((b) => b.id === expanded);
+
   return (
-    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-4 p-4">
+    <div className="p-4">
+      <div className="badge-stack">
+        {badgeDefs.map((b) => {
+          const earned = earnedBadges.includes(b.id);
+          return (
+            <div key={b.id} className="relative z-0 hover:z-10">
+              {earned ? (
+                <img
+                  src={b.image}
+                  alt={b.title}
+                  className="badge-box rounded-full border object-cover cursor-pointer"
+                  onClick={() => setExpanded(b.id)}
+                />
+              ) : (
+                <div className="badge-box rounded-full border bg-white"></div>
+              )}
+            </div>
+          );
+        })}
+      </div>
 
-      {badgeDefs.map((b) => {
-        const earned = earnedBadges.includes(b.id);
-        return (
-          <div key={b.id} className="flex flex-col items-center text-sm">
-            {earned ? (
-              <img
-                src={b.image}
-                alt={b.title}
-                className="badge-box rounded-full border object-cover"
-              />
-            ) : (
-              <div className="badge-box rounded-full border bg-white"></div>
-            )}
-            <div className="mt-2 text-center">{b.title}</div>
-          </div>
-        );
-      })}
-
+      {expandedBadge && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+          onClick={() => setExpanded(null)}
+        >
+          <img
+            src={expandedBadge.image}
+            alt={expandedBadge.title}
+            className="max-w-full max-h-full cursor-pointer object-contain"
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -216,6 +216,32 @@ select:focus {
   }
 }
 
+/* Stacked badge layout */
+.badge-stack {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.badge-stack > * {
+  margin-left: -1rem;
+}
+
+.badge-stack > *:nth-child(3n + 1) {
+  margin-left: 0;
+}
+
+@media (min-width: 640px) {
+  .badge-stack > *:nth-child(4n + 1) {
+    margin-left: 0;
+  }
+}
+
+@media (min-width: 768px) {
+  .badge-stack > *:nth-child(6n + 1) {
+    margin-left: 0;
+  }
+}
+
 /* Header/menu styles */
 .app-header {
   position: relative;


### PR DESCRIPTION
## Summary
- stack badge icons responsively so rows adapt to screen width
- show full badge image in overlay with object-contain when clicked

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab674d7604832e83a23708863a1be0