### PR TITLE
Add student password support with reset codes

### DIFF
--- a/src/components/ui.js
+++ b/src/components/ui.js
@@ -22,9 +22,10 @@ export function Button({ children, onClick, type = 'button', className = '', dis
   );
 }
 
-export function TextInput({ value, onChange, placeholder, className = '' }) {
+export function TextInput({ value, onChange, placeholder, type = 'text', className = '' }) {
   return (
     <input
+      type={type}
       value={value}
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder}

--- a/src/data/students.json
+++ b/src/data/students.json
@@ -1,5 +1,5 @@
 [
-  { "id": "s1", "name": "Alex",  "email": "alex@student.nhlstenden.com",  "groupId": "g1", "points": 10, "badges": [] },
-  { "id": "s2", "name": "Bo",    "email": "bo@student.nhlstenden.com",    "groupId": "g1", "points": 5,  "badges": [] },
-  { "id": "s3", "name": "Casey", "email": "casey@student.nhlstenden.com", "groupId": "g2", "points": 12, "badges": [] }
+  { "id": "s1", "name": "Alex",  "email": "alex@student.nhlstenden.com",  "password": "1234", "groupId": "g1", "points": 10, "badges": [] },
+  { "id": "s2", "name": "Bo",    "email": "bo@student.nhlstenden.com",    "password": "1234", "groupId": "g1", "points": 5,  "badges": [] },
+  { "id": "s3", "name": "Casey", "email": "casey@student.nhlstenden.com", "password": "1234", "groupId": "g2", "points": 12, "badges": [] }
 ]


### PR DESCRIPTION
## Summary
- allow students to sign up and log in with passwords
- add teacher-admin password reset that issues a temporary code
- support password inputs in shared TextInput component

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68acb6d0f920832e99f90ebf90b0daae