### PR TITLE
Implement hashed teacher login and admin management

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1"

--- a/src/data/teachers.json
+++ b/src/data/teachers.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "t1",
+    "email": "sake.jan.velthuis@nhlstenden.com",
+    "passwordHash": "$2a$10$cdRJTj5JR2Qa8WyYxCWDcOQPaSeSEeWBzoyS7tEAcwnDccf1Xi13C"
+  }
+]

--- a/src/hooks/useTeachers.js
+++ b/src/hooks/useTeachers.js
@@ -1,0 +1,8 @@
+import usePersistentState from './usePersistentState';
+import seedTeachers from '../data/teachers.json';
+
+const LS_KEY = 'nm_points_teachers_v1';
+
+export default function useTeachers() {
+  return usePersistentState(LS_KEY, seedTeachers);
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,9 @@ export function genId() {
 const EMAIL_RE = /@student\.nhlstenden\.com$/i;
 export const emailValid = (email) => EMAIL_RE.test((email || '').trim());
 
+const TEACHER_EMAIL_RE = /@nhlstenden\.com$/i;
+export const teacherEmailValid = (email) => TEACHER_EMAIL_RE.test((email || '').trim());
+
 export function nameFromEmail(email) {
   const prefix = (email || '').split('@')[0];
   const parts = prefix.split('.').filter(Boolean);


### PR DESCRIPTION
## Summary
- secure admin access with teacher email/password login backed by bcrypt hashes
- add teacher management page and persistent storage, seeded with initial teacher
- include teachers in backup/restore and add bcryptjs dependency

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68acb7c3652c832eb637c913828f3add