### PR TITLE
Display centered splash image on role selection page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,8 +33,19 @@ export default function App() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 p-4 md:p-8 text-slate-800">
-      <div className="max-w-6xl mx-auto">
+    <div className="relative min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 p-4 md:p-8 text-slate-800 overflow-hidden">
+      {route === '/' && (
+        <picture className="pointer-events-none absolute inset-0 m-auto h-full w-auto max-h-screen">
+          <source srcSet="images/voorpagina.webp" type="image/webp" />
+          <source srcSet="images/voorpagina.png" type="image/png" />
+          <img
+            src="images/voorpagina.jpg"
+            alt="Voorpagina"
+            className="h-full w-auto object-contain"
+          />
+        </picture>
+      )}
+      <div className="relative z-10 max-w-6xl mx-auto">
         <header className="app-header">
           <h1 className="app-title">Neuromarketing Housepoints</h1>
           {route !== '/' && (


### PR DESCRIPTION
## Summary
- show `voorpagina` illustration behind login buttons and scale to screen height

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68acbc63228c832eaa1f3e8120ba232f