### PR TITLE
fix resetStudentId initialization bug in Admin component

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -145,6 +145,9 @@ export default function Admin() {
     reader.readAsText(file);
   }, [setStudents, setGroups, setAwards, setBadgeDefs, setTeachers]);
 
+  const [resetStudentId, setResetStudentId] = useState(students[0]?.id || '');
+  const [resetCode, setResetCode] = useState('');
+
   const handleResetPassword = useCallback(() => {
     if (!resetStudentId) return;
     const code = Math.random().toString(36).slice(2, 8);
@@ -160,8 +163,6 @@ export default function Admin() {
   const [assignGroupId, setAssignGroupId] = useState(groups[0]?.id || '');
 
   const [removeStudentId, setRemoveStudentId] = useState(students[0]?.id || '');
-  const [resetStudentId, setResetStudentId] = useState(students[0]?.id || '');
-  const [resetCode, setResetCode] = useState('');
 
   const [page, setPage] = useState('add-student');
 


### PR DESCRIPTION
## Summary
- move reset password state declarations above the reset handler to avoid accessing them before initialization

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68acc7a9648c832e8ade5646233c302f