### PR TITLE
Show student email in preview

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -722,7 +722,7 @@ export default function Admin() {
                 <option value="">— Kies student —</option>
                 {students.map((s) => (
                   <option key={s.id} value={s.id}>
-                    {s.name} ({s.id})
+                    {s.name} ({s.email || s.id})
                   </option>
                 ))}
               </Select>

--- a/src/App.js
+++ b/src/App.js
@@ -209,9 +209,10 @@ function AdminPreview({ selectedStudentId, setSelectedStudentId }) {
               {students.map((s, i) => {
                 const id = toId(s, i);
                 const name = toName(s, id);
+                const email = typeof s === 'string' ? '' : s?.email;
                 return (
                   <option key={id} value={id}>
-                    {name} ({id})
+                    {name} ({email || id})
                   </option>
                 );
               })}

--- a/src/Student.js
+++ b/src/Student.js
@@ -277,7 +277,7 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
       <div className="max-w-3xl mx-auto">
         {me && (
           <div className="flex items-center justify-between mb-4">
-            <span>Ingelogd als {me.name}</span>
+            <span>Ingelogd als {me.name}{me.email ? ` (${me.email})` : ''}</span>
             <Button className="bg-indigo-600 text-white" onClick={handleLogout}>Uitloggen</Button>
           </div>
         )}
@@ -303,7 +303,7 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
     <div>
       {me && (
         <div className="flex items-center justify-between mb-4">
-          <span>Ingelogd als {me.name}</span>
+          <span>Ingelogd als {me.name}{me.email ? ` (${me.email})` : ''}</span>
           <Button className="bg-indigo-600 text-white" onClick={handleLogout}>Uitloggen</Button>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Display student email next to name when previewing a student
- Include student email in preview dropdowns for easier identification

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68accb0a953c832ea41bad51a71b6c4b