### PR TITLE
Show voorpagina image on login page

### DIFF
--- a/src/Student.js
+++ b/src/Student.js
@@ -174,6 +174,11 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
   if (!selectedStudentId) {
     return (
       <div className="max-w-md mx-auto">
+        <img
+          src="images/voorpagina.png"
+          alt="Voorpagina"
+          className="w-full h-auto mb-4"
+        />
         {authMode === 'login' ? (
           <Card title="Log in">
             <div className="grid grid-cols-1 gap-4">


### PR DESCRIPTION
## Summary
- Display `voorpagina.png` above login form

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68acd42a9d58832ea7423532b999a0b8