### PR TITLE
Show badge awards in recent activities

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -57,17 +57,34 @@ export default function Admin() {
     return id;
   }, [setGroups]);
 
-  const toggleStudentBadge = useCallback((studentId, badgeId, hasBadge) => {
-    if (!studentId || !badgeId) return;
-    setStudents((prev) =>
-      prev.map((s) => {
-        if (s.id !== studentId) return s;
-        const current = new Set(s.badges || []);
-        if (hasBadge) current.add(badgeId); else current.delete(badgeId);
-        return { ...s, badges: Array.from(current) };
-      })
-    );
-  }, [setStudents]);
+  const toggleStudentBadge = useCallback(
+    (studentId, badgeId, hasBadge) => {
+      if (!studentId || !badgeId) return;
+      setStudents((prev) =>
+        prev.map((s) => {
+          if (s.id !== studentId) return s;
+          const current = new Set(s.badges || []);
+          if (hasBadge) current.add(badgeId);
+          else current.delete(badgeId);
+          return { ...s, badges: Array.from(current) };
+        })
+      );
+      if (hasBadge) {
+        const badge = badgeDefs.find((b) => b.id === badgeId);
+        const award = {
+          id: genId(),
+          ts: Date.now(),
+          type: 'student',
+          targetId: studentId,
+          amount: 0,
+          reason: `Badge toegekend: ${badge?.title || badgeId}`,
+          badgeId,
+        };
+        setAwards((prev) => [award, ...prev].slice(0, 500));
+      }
+    },
+    [setStudents, setAwards, badgeDefs]
+  );
 
   const awardToStudent = useCallback((studentId, amount, reason) => {
     if (!studentId || !Number.isFinite(amount)) return;

--- a/src/Student.js
+++ b/src/Student.js
@@ -321,14 +321,25 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
         <Card title="Jouw recente activiteiten" className="lg:col-span-2 max-h-[320px] overflow-auto">
         <ul className="space-y-2 text-sm">
           {myAwards.length === 0 && <li>Geen recente items.</li>}
-          {myAwards.map((a) => (
-            <li key={a.id} className="flex justify-between gap-2">
-              <span>
-                {new Date(a.ts).toLocaleString()} · {a.type === 'student' ? 'Individueel' : `Groep (${myGroup?.name || '-'})`} {a.reason ? `— ${a.reason}` : ''}
-              </span>
-              <span className={`font-semibold ${a.amount >= 0 ? 'text-emerald-700' : 'text-rose-700'}`}>{a.amount >= 0 ? '+' : ''}{a.amount}</span>
-            </li>
-          ))}
+          {myAwards.map((a) => {
+            const badge = a.badgeId ? badgeDefs.find((b) => b.id === a.badgeId) : null;
+            return (
+              <li key={a.id} className="flex justify-between gap-2">
+                <span>
+                  {new Date(a.ts).toLocaleString()} ·
+                  {badge
+                    ? ` Badge — ${badge?.title || ''}`
+                    : `${a.type === 'student' ? 'Individueel' : `Groep (${myGroup?.name || '-'})`}${a.reason ? ` — ${a.reason}` : ''}`}
+                </span>
+                {!badge && (
+                  <span className={`font-semibold ${a.amount >= 0 ? 'text-emerald-700' : 'text-rose-700'}`}>
+                    {a.amount >= 0 ? '+' : ''}
+                    {a.amount}
+                  </span>
+                )}
+              </li>
+            );
+          })}
         </ul>
         </Card>
 


### PR DESCRIPTION
## Summary
- log a zero-point award when a badge is granted to a student
- display badge awards in the student's recent activity list

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68acd21d0ecc832e9226226fda6aaed8