### PR TITLE
Refactor password hashing to avoid bcrypt polyfill errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "house-of-neuro",
       "version": "0.1.0",
       "dependencies": {
-        "bcryptjs": "^2.4.3",
+        "crypto-js": "^4.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1"
@@ -5395,12 +5395,6 @@
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "license": "MIT"
     },
-    "node_modules/bcryptjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
-      "license": "MIT"
-    },
     "node_modules/bfj": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.1.0.tgz",
@@ -6219,6 +6213,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "bcryptjs": "^2.4.3",
+    "crypto-js": "^4.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1"

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -9,7 +9,7 @@ import Student from './Student';
 import useBadges from './hooks/useBadges';
 import usePersistentState from './hooks/usePersistentState';
 import useTeachers from './hooks/useTeachers';
-import bcrypt from 'bcryptjs';
+import { hashPassword } from './utils/password';
 
 export default function Admin() {
   const [students, setStudents] = useStudents();
@@ -40,9 +40,10 @@ export default function Admin() {
 
   const addStudent = useCallback((name, email, password = '') => {
     const id = genId();
+    const passwordHash = password ? hashPassword(password) : '';
     setStudents((prev) => [
       ...prev,
-      { id, name, email: email || undefined, password, groupId: null, points: 0, badges: [] }
+      { id, name, email: email || undefined, passwordHash, groupId: null, points: 0, badges: [] }
     ]);
     return id;
   }, [setStudents]);
@@ -108,7 +109,7 @@ export default function Admin() {
   const resetTeacherPassword = useCallback((id) => {
     const pwd = window.prompt('Nieuw wachtwoord:');
     if (!pwd?.trim()) return;
-    const hash = bcrypt.hashSync(pwd.trim(), 10);
+    const hash = hashPassword(pwd.trim());
     setTeachers((prev) =>
       prev.map((t) => (t.id === id ? { ...t, passwordHash: hash } : t))
     );
@@ -181,7 +182,7 @@ export default function Admin() {
     const code = Math.random().toString(36).slice(2, 8);
     setStudents((prev) =>
       prev.map((s) =>
-        s.id === resetStudentId ? { ...s, password: '', tempCode: code } : s
+        s.id === resetStudentId ? { ...s, passwordHash: '', tempCode: code } : s
       )
     );
     setResetCode(code);
@@ -581,7 +582,7 @@ export default function Admin() {
               onClick={() => {
                 const email = newTeacherEmail.trim().toLowerCase();
                 if (teachers.some((t) => t.email.toLowerCase() === email)) return;
-                const hash = bcrypt.hashSync(newTeacherPassword.trim(), 10);
+                const hash = hashPassword(newTeacherPassword.trim());
                 setTeachers((prev) => [...prev, { id: genId(), email, passwordHash: hash }]);
                 setNewTeacherEmail('');
                 setNewTeacherPassword('');

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ import usePersistentState from './hooks/usePersistentState';
 import useStudents from './hooks/useStudents';
 import useTeachers from './hooks/useTeachers';
 import { teacherEmailValid, genId } from './utils';
-import bcrypt from 'bcryptjs';
+import { hashPassword, comparePassword } from './utils/password';
 
 export default function App() {
   const getRoute = () => (typeof location !== 'undefined' && location.hash ? location.hash.slice(1) : '/');
@@ -123,7 +123,7 @@ function AdminGate({ onAllow }) {
       return;
     }
     const t = teachers.find((te) => te.email.toLowerCase() === norm);
-    if (t && bcrypt.compareSync(loginPassword, t.passwordHash)) {
+    if (t && comparePassword(loginPassword, t.passwordHash)) {
       setLoginError('');
       onAllow();
     } else {
@@ -142,7 +142,7 @@ function AdminGate({ onAllow }) {
       setSignupError('E-mailadres bestaat al.');
       return;
     }
-    const hash = bcrypt.hashSync(signupPassword.trim(), 10);
+    const hash = hashPassword(signupPassword.trim());
     setTeachers((prev) => [...prev, { id: genId(), email: norm, passwordHash: hash }]);
     setSignupEmail('');
     setSignupPassword('');
@@ -336,14 +336,14 @@ function RoleSelect() {
     
     if (norm.endsWith('@student.nhlstenden.com')) {
       const student = students.find(s => s.email?.toLowerCase() === norm);
-      if (student && bcrypt.compareSync(password, student.passwordHash)) {
+      if (student && comparePassword(password, student.passwordHash)) {
         window.location.hash = '/student';
       } else {
         setError('Onjuiste e-mail of wachtwoord.');
       }
     } else if (norm.endsWith('@nhlstenden.com')) {
       const teacher = teachers.find(t => t.email.toLowerCase() === norm);
-      if (teacher && bcrypt.compareSync(password, teacher.passwordHash)) {
+      if (teacher && comparePassword(password, teacher.passwordHash)) {
         if (!teacher.approved) {
           setError('Account wacht nog op goedkeuring van een beheerder.');
           return;
@@ -373,7 +373,7 @@ function RoleSelect() {
         setError('E-mailadres bestaat al.');
         return;
       }
-      const hash = bcrypt.hashSync(password.trim(), 10);
+      const hash = hashPassword(password.trim());
       setStudents(prev => [...prev, { 
         id: genId(), 
         email: norm, 
@@ -386,7 +386,7 @@ function RoleSelect() {
         setError('E-mailadres bestaat al.');
         return;
       }
-      const hash = bcrypt.hashSync(password.trim(), 10);
+      const hash = hashPassword(password.trim());
       setTeachers(prev => [...prev, { 
         id: genId(), 
         email: norm, 

--- a/src/Student.js
+++ b/src/Student.js
@@ -5,6 +5,7 @@ import useStudents from './hooks/useStudents';
 import useGroups from './hooks/useGroups';
 import useAwards from './hooks/useAwards';
 import { genId, emailValid, getIndividualLeaderboard, getGroupLeaderboard, nameFromEmail } from './utils';
+import { hashPassword, comparePassword } from './utils/password';
 import useBadges from './hooks/useBadges';
 
 export default function Student({ selectedStudentId, setSelectedStudentId }) {
@@ -28,9 +29,10 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
 
   const addStudent = useCallback((name, email, password = '') => {
     const id = genId();
+    const passwordHash = password ? hashPassword(password) : '';
     setStudents((prev) => [
       ...prev,
-      { id, name, email: email || undefined, password, groupId: null, points: 0, badges: [] }
+      { id, name, email: email || undefined, passwordHash, groupId: null, points: 0, badges: [] }
     ]);
     return id;
   }, [setStudents]);
@@ -80,7 +82,7 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
         setLoginEmail('');
         setLoginPassword('');
         setLoginError('');
-      } else if ((existing.password || '') === pass) {
+      } else if (comparePassword(pass, existing.passwordHash)) {
         setSelectedStudentId(existing.id);
         setLoginEmail('');
         setLoginPassword('');
@@ -132,8 +134,9 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
     if (!newPassword.trim() || newPassword !== newPassword2) return;
     const id = resetStudent.id;
     const pass = newPassword.trim();
+    const hash = hashPassword(pass);
     setStudents((prev) =>
-      prev.map((s) => (s.id === id ? { ...s, password: pass, tempCode: undefined } : s))
+      prev.map((s) => (s.id === id ? { ...s, passwordHash: hash, tempCode: undefined } : s))
     );
     setResetStudent(null);
     setSelectedStudentId(id);

--- a/src/data/students.json
+++ b/src/data/students.json
@@ -1,5 +1,5 @@
 [
-  { "id": "s1", "name": "Alex",  "email": "alex@student.nhlstenden.com",  "password": "1234", "groupId": "g1", "points": 10, "badges": [] },
-  { "id": "s2", "name": "Bo",    "email": "bo@student.nhlstenden.com",    "password": "1234", "groupId": "g1", "points": 5,  "badges": [] },
-  { "id": "s3", "name": "Casey", "email": "casey@student.nhlstenden.com", "password": "1234", "groupId": "g2", "points": 12, "badges": [] }
+  { "id": "s1", "name": "Alex",  "email": "alex@student.nhlstenden.com",  "passwordHash": "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4", "groupId": "g1", "points": 10, "badges": [] },
+  { "id": "s2", "name": "Bo",    "email": "bo@student.nhlstenden.com",    "passwordHash": "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4", "groupId": "g1", "points": 5,  "badges": [] },
+  { "id": "s3", "name": "Casey", "email": "casey@student.nhlstenden.com", "passwordHash": "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4", "groupId": "g2", "points": 12, "badges": [] }
 ]

--- a/src/data/teachers.json
+++ b/src/data/teachers.json
@@ -2,6 +2,6 @@
   {
     "id": "t1",
     "email": "sake.jan.velthuis@nhlstenden.com",
-    "passwordHash": "$2a$10$cdRJTj5JR2Qa8WyYxCWDcOQPaSeSEeWBzoyS7tEAcwnDccf1Xi13C"
+    "passwordHash": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
   }
 ]

--- a/src/utils/password.js
+++ b/src/utils/password.js
@@ -1,0 +1,10 @@
+import SHA256 from 'crypto-js/sha256';
+
+export function hashPassword(password) {
+  return SHA256(password).toString();
+}
+
+export function comparePassword(password, hash) {
+  if (!hash) return false;
+  return hashPassword(password) === hash;
+}


### PR DESCRIPTION
## Summary
- Replace bcryptjs with a simple SHA-256 based password utility
- Update login, signup, and admin flows to use new hash helpers
- Refresh seed user data to store SHA-256 password hashes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad8e977cb0832e9756ced8f68fa2db