### PR TITLE
Fix duplicated logout and restore student points overview toggle

### DIFF
--- a/src/Student.js
+++ b/src/Student.js
@@ -173,7 +173,7 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
 
   return (
     <div className="relative">
-      {/* Add background image container */}
+      {/* Background image */}
       <div className="fixed inset-0 z-0">
         <img
           src={process.env.PUBLIC_URL + '/images/voorpagina.png'}
@@ -182,9 +182,9 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
         />
       </div>
 
-      {/* Main content with higher z-index */}
+      {/* Main content */}
       <div className="relative z-10">
-        {me && (
+        {selectedStudentId && me && (
           <div className="flex items-center justify-between mb-4">
             <span className="bg-white/90 px-2 py-1 rounded">
               Ingelogd als {me.name}{me.email ? ` (${me.email})` : ''}
@@ -195,7 +195,6 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
           </div>
         )}
 
-        {/* Remove the old image from the login section */}
         {!selectedStudentId ? (
           <div className="max-w-md mx-auto">
             {authMode === 'login' ? (
@@ -293,27 +292,103 @@ export default function Student({ selectedStudentId, setSelectedStudentId }) {
               </Card>
             )}
           </div>
-        ) : (
+        ) : showBadges ? (
           <div className="max-w-3xl mx-auto">
-            {me && (
-              <div className="flex items-center justify-between mb-4">
-                <span>Ingelogd als {me.name}{me.email ? ` (${me.email})` : ''}</span>
-                <Button className="bg-indigo-600 text-white" onClick={handleLogout}>Uitloggen</Button>
-              </div>
-            )}
             <Card title="Verdiende badges">
+              <div className="sticky top-0 bg-white pb-4 z-10">
+                <Button className="bg-indigo-600 text-white" onClick={() => setShowBadges(false)}>
+                  Terug naar puntenoverzicht
+                </Button>
+              </div>
+              <BadgeOverview badgeDefs={badgeDefs} earnedBadges={myBadges} />
+            </Card>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
+            <Card title="Badges" className="lg:col-span-3">
               {me ? (
-                <>
-                  <div className="sticky top-0 bg-white pb-4 z-10">
-                    <Button className="bg-indigo-600 text-white" onClick={() => setShowBadges(false)}>
-                      Terug naar puntenoverzicht
-                    </Button>
-                  </div>
-                  <BadgeOverview badgeDefs={badgeDefs} earnedBadges={myBadges} />
-                </>
+                <Button className="bg-indigo-600 text-white" onClick={() => setShowBadges(true)}>
+                  Bekijk badges
+                </Button>
               ) : (
                 <p className="text-sm text-neutral-600">Selecteer een student om badges te bekijken.</p>
               )}
+            </Card>
+
+            <Card title="Jouw recente activiteiten" className="lg:col-span-2 max-h-[320px] overflow-auto">
+              <ul className="space-y-2 text-sm">
+                {myAwards.length === 0 && <li>Geen recente items.</li>}
+                {myAwards.map((a) => (
+                  <li key={a.id} className="flex justify-between gap-2">
+                    <span>
+                      {new Date(a.ts).toLocaleString()} · {a.type === 'student' ? 'Individueel' : `Groep (${myGroup?.name || '-'})`}{' '}
+                      {a.reason ? `— ${a.reason}` : ''}
+                    </span>
+                    <span className={`font-semibold ${a.amount >= 0 ? 'text-emerald-700' : 'text-rose-700'}`}>{a.amount >= 0 ? '+' : ''}{a.amount}</span>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+
+            <Card title="Leaderboard – Individueel" className="lg:col-span-2">
+              <table className="w-full text-sm whitespace-nowrap">
+                <thead>
+                  <tr className="text-left border-b">
+                    <th className="py-1 pr-2">#</th>
+                    <th className="py-1 pr-2">Student</th>
+                    <th className="py-1 pr-2 text-right">Punten</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(() => {
+                    const top3 = individualLeaderboard.slice(0, 3);
+                    const meRow = individualLeaderboard.find((r) => r.id === selectedStudentId);
+                    const isTop3 = meRow && meRow.rank <= 3;
+                    return (
+                      <>
+                        {top3.map((row) => (
+                          <tr key={row.id} className={`border-b last:border-0 ${row.id === selectedStudentId ? 'bg-indigo-50' : ''}`}>
+                            <td className="py-1 pr-2">{row.rank}</td>
+                            <td className="py-1 pr-2">{row.name}</td>
+                            <td className={`py-1 pr-2 text-right font-semibold ${row.points > 0 ? 'text-emerald-700' : row.points < 0 ? 'text-rose-700' : 'text-neutral-700'}`}>{row.points}</td>
+                          </tr>
+                        ))}
+                        {!isTop3 && meRow && (
+                          <>
+                            <tr className="border-b"><td colSpan="3" className="py-1"></td></tr>
+                            <tr className="bg-indigo-50">
+                              <td className="py-1 pr-2">{meRow.rank}</td>
+                              <td className="py-1 pr-2">{meRow.name}</td>
+                              <td className={`py-1 pr-2 text-right font-semibold ${meRow.points > 0 ? 'text-emerald-700' : meRow.points < 0 ? 'text-rose-700' : 'text-neutral-700'}`}>{meRow.points}</td>
+                            </tr>
+                          </>
+                        )}
+                      </>
+                    );
+                  })()}
+                </tbody>
+              </table>
+            </Card>
+
+            <Card title="Leaderboard – Groepen" className="lg:col-span-3">
+              <table className="w-full text-sm whitespace-nowrap">
+                <thead>
+                  <tr className="text-left border-b">
+                    <th className="py-1 pr-2">#</th>
+                    <th className="py-1 pr-2">Groep</th>
+                    <th className="py-1 pr-2 text-right">Totaal</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {groupLeaderboard.map((row) => (
+                    <tr key={row.id} className={row.id === myGroup?.id ? 'bg-indigo-50' : ''}>
+                      <td className="py-1 pr-2">{row.rank}</td>
+                      <td className="py-1 pr-2">{row.name}</td>
+                      <td className={`py-1 pr-2 text-right font-semibold ${row.total > 0 ? 'text-emerald-700' : row.total < 0 ? 'text-rose-700' : 'text-neutral-700'}`}>{row.total}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </Card>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Reintroduce points overview and badges toggle for students
- Show logged-in student and logout button only once
- Make "Terug naar puntenoverzicht" button switch back from badge view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adddfdc4e0832ebdf883258223598b