### PR TITLE
Allow admin to preview student data without login

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -7,7 +7,6 @@ import useAwards from './hooks/useAwards';
 import { genId, emailValid, getIndividualLeaderboard, getGroupLeaderboard, teacherEmailValid } from './utils';
 import Student from './Student';
 import useBadges from './hooks/useBadges';
-import usePersistentState from './hooks/usePersistentState';
 import useTeachers from './hooks/useTeachers';
 import bcrypt from 'bcryptjs';
 
@@ -183,7 +182,7 @@ export default function Admin() {
   const [page, setPage] = useState('add-student');
 
   // Preview state (gedeeld met Student-weergave via localStorage)
-  const [selectedStudentId, setSelectedStudentId] = usePersistentState('nm_points_current_student', '');
+  const [previewId, setPreviewId] = useState('');
 
   useEffect(() => {
     if (students.length === 0) {
@@ -228,10 +227,10 @@ export default function Admin() {
 
   // Houd preview-selectie geldig als de lijst verandert
   useEffect(() => {
-    if (selectedStudentId && !students.find((s) => s.id === selectedStudentId)) {
-      setSelectedStudentId(students[0]?.id || '');
+    if (previewId && !students.find((s) => s.id === previewId)) {
+      setPreviewId(students[0]?.id || '');
     }
-  }, [students, selectedStudentId, setSelectedStudentId]);
+  }, [students, previewId]);
 
   return (
     <div className="space-y-4">
@@ -771,7 +770,7 @@ export default function Admin() {
           <div className="grid grid-cols-1 gap-2 md:grid-cols-2 md:items-end">
             <div>
               <label className="text-sm">Student</label>
-              <Select value={selectedStudentId} onChange={setSelectedStudentId}>
+              <Select value={previewId} onChange={setPreviewId}>
                 <option value="">— Kies student —</option>
                 {students.map((s) => (
                   <option key={s.id} value={s.id}>
@@ -784,16 +783,13 @@ export default function Admin() {
               </p>
             </div>
             <div className="flex gap-2">
-              <Button className="border" onClick={() => setSelectedStudentId('')}>Leegmaken</Button>
+              <Button className="border" onClick={() => setPreviewId('')}>Leegmaken</Button>
               <a href="#/admin/preview" className="px-4 py-2 rounded-2xl border">Open als losse pagina</a>
             </div>
           </div>
 
           <div className="mt-4">
-            <Student
-              selectedStudentId={selectedStudentId}
-              setSelectedStudentId={setSelectedStudentId}
-            />
+            <Student previewStudentId={previewId} />
           </div>
         </Card>
       )}

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -9,6 +9,7 @@ import Student from './Student';
 import useBadges from './hooks/useBadges';
 import useTeachers from './hooks/useTeachers';
 import bcrypt from 'bcryptjs';
+import usePersistentState from './hooks/usePersistentState';
 
 export default function Admin() {
   const [students, setStudents] = useStudents();
@@ -182,7 +183,7 @@ export default function Admin() {
   const [page, setPage] = useState('add-student');
 
   // Preview state (gedeeld met Student-weergave via localStorage)
-  const [previewId, setPreviewId] = useState('');
+  const [previewId, setPreviewId] = usePersistentState('nm_preview_student', '');
 
   useEffect(() => {
     if (students.length === 0) {

--- a/src/App.js
+++ b/src/App.js
@@ -142,10 +142,7 @@ export default function App() {
           )
         ) : route === '/admin/preview' ? (
           isAdmin ? (
-            <AdminPreview
-              selectedStudentId={selectedStudentId}
-              setSelectedStudentId={setSelectedStudentId}
-            />
+            <AdminPreview />
           ) : (
             <Auth
               onAdminLogin={() => {
@@ -176,7 +173,8 @@ export default function App() {
 }
 
 /* AdminPreview: dropdown met studenten uit useStudents */
-function AdminPreview({ selectedStudentId, setSelectedStudentId }) {
+function AdminPreview() {
+  const [previewId, setPreviewId] = useState('');
   const studentsHook = useStudents();
   // Ondersteun zowel return van [students, setStudents] als direct students
   const studentsRaw =
@@ -207,8 +205,8 @@ function AdminPreview({ selectedStudentId, setSelectedStudentId }) {
           <div className="flex-1">
             <label className="block text-sm text-neutral-600 mb-1">Selecteer student</label>
             <select
-              value={selectedStudentId}
-              onChange={(e) => setSelectedStudentId(e.target.value)}
+              value={previewId}
+              onChange={(e) => setPreviewId(e.target.value)}
               className="w-full rounded-2xl border border-slate-300 px-3 py-2 bg-white"
             >
               <option value="">— Geen selectie —</option>
@@ -228,17 +226,14 @@ function AdminPreview({ selectedStudentId, setSelectedStudentId }) {
             </p>
           </div>
           <div className="flex gap-2">
-            <Button className="border" onClick={() => setSelectedStudentId('')}>Leegmaken</Button>
+            <Button className="border" onClick={() => setPreviewId('')}>Leegmaken</Button>
             <a href="#/admin" className="px-4 py-2 rounded-2xl border">Terug naar beheer</a>
           </div>
         </div>
       </Card>
 
       <div className="mt-6">
-        <Student
-          selectedStudentId={selectedStudentId}
-          setSelectedStudentId={setSelectedStudentId}
-        />
+        <Student previewStudentId={previewId} />
       </div>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -174,7 +174,7 @@ export default function App() {
 
 /* AdminPreview: dropdown met studenten uit useStudents */
 function AdminPreview() {
-  const [previewId, setPreviewId] = useState('');
+  const [previewId, setPreviewId] = usePersistentState('nm_preview_student', '');
   const studentsHook = useStudents();
   // Ondersteun zowel return van [students, setStudents] als direct students
   const studentsRaw =

--- a/src/Student.js
+++ b/src/Student.js
@@ -17,7 +17,9 @@ export default function Student({
   const [awards] = useAwards();
   const [badgeDefs] = useBadges();
 
-  const activeStudentId = previewStudentId ?? selectedStudentId;
+  const inPreview = previewStudentId !== undefined;
+  const activeStudentId = inPreview ? previewStudentId : selectedStudentId;
+  const bgPosClass = inPreview ? 'absolute' : 'fixed';
 
   const groupById = useMemo(() => {
     const m = new Map();
@@ -42,10 +44,10 @@ export default function Student({
   }, [setStudents]);
 
   useEffect(() => {
-    if (!previewStudentId && selectedStudentId && !students.find((s) => s.id === selectedStudentId)) {
+    if (!inPreview && selectedStudentId && !students.find((s) => s.id === selectedStudentId)) {
       setSelectedStudentId('');
     }
-  }, [students, selectedStudentId, setSelectedStudentId, previewStudentId]);
+  }, [students, selectedStudentId, setSelectedStudentId, inPreview]);
 
   const me = students.find((s) => s.id === activeStudentId) || null;
   const myGroup = me && me.groupId ? groupById.get(me.groupId) || null : null;
@@ -190,7 +192,7 @@ export default function Student({
   return (
     <div className="relative">
       {/* Background image */}
-      <div className="fixed inset-0 z-0">
+      <div className={`${bgPosClass} inset-0 z-0 pointer-events-none`}>
         <img
           src={process.env.PUBLIC_URL + '/images/voorpagina.png'}
           alt="Background"
@@ -201,7 +203,7 @@ export default function Student({
       {/* Main content */}
       <div className="relative z-10">
         {activeStudentId && me && (
-          previewStudentId ? (
+          inPreview ? (
             <div className="flex items-center justify-between mb-4">
               <span className="bg-white/90 px-2 py-1 rounded">
                 Preview van {me.name}{me.email ? ` (${me.email})` : ''}
@@ -220,102 +222,112 @@ export default function Student({
         )}
 
         {!activeStudentId ? (
-          <div className="max-w-md mx-auto">
-            {authMode === 'login' ? (
-              <Card title="Log in">
-                <div className="grid grid-cols-1 gap-4">
-                  <TextInput value={loginEmail} onChange={setLoginEmail} placeholder="E-mail (@student.nhlstenden.com)" />
-                  <TextInput
-                    type="password"
-                    value={loginPassword}
-                    onChange={setLoginPassword}
-                    placeholder="Wachtwoord of code"
-                  />
-                  {loginEmail && !emailValid(loginEmail) && (
-                    <div className="text-sm text-rose-600">Alleen adressen eindigend op @student.nhlstenden.com zijn toegestaan.</div>
-                  )}
-                  {loginError && <div className="text-sm text-rose-600">{loginError}</div>}
-                  <Button
-                    className="bg-indigo-600 text-white"
-                    disabled={!loginEmail.trim() || !emailValid(loginEmail) || !loginPassword.trim()}
-                    onClick={handleLogin}
-                  >
-                    Log in
-                  </Button>
-                  <button
-                    className="text-sm text-indigo-600 text-left"
-                    onClick={() => {
-                      setSignupEmail('');
-                      setSignupName('');
-                      setSignupPassword('');
-                      setSignupPassword2('');
-                      setSignupError('');
-                      setAuthMode('signup');
-                    }}
-                  >
-                    Account aanmaken
-                  </button>
-                </div>
+          inPreview ? (
+            <div className="max-w-md mx-auto">
+              <Card title="Geen student geselecteerd">
+                <p className="text-sm text-neutral-700">
+                  Selecteer een student om de preview te zien.
+                </p>
               </Card>
-            ) : (
-              <Card title="Account aanmaken">
-                <div className="grid grid-cols-1 gap-4">
-                  <TextInput
-                    value={signupEmail}
-                    onChange={(v) => {
-                      setSignupEmail(v);
-                      setSignupName(nameFromEmail(v));
-                    }}
-                    placeholder="E-mail (@student.nhlstenden.com)"
-                  />
-                  {signupEmail && !emailValid(signupEmail) && (
-                    <div className="text-sm text-rose-600">Alleen adressen eindigend op @student.nhlstenden.com zijn toegestaan.</div>
-                  )}
-                  <TextInput value={signupName} onChange={setSignupName} placeholder="Volledige naam" />
-                  <TextInput
-                    type="password"
-                    value={signupPassword}
-                    onChange={setSignupPassword}
-                    placeholder="Wachtwoord"
-                  />
-                  <TextInput
-                    type="password"
-                    value={signupPassword2}
-                    onChange={setSignupPassword2}
-                    placeholder="Bevestig wachtwoord"
-                  />
-                  {signupError && <div className="text-sm text-rose-600">{signupError}</div>}
-                  <Button
-                    className="bg-indigo-600 text-white"
-                    disabled={
-                      !signupEmail.trim() ||
-                      !signupName.trim() ||
-                      !emailValid(signupEmail) ||
-                      !signupPassword.trim() ||
-                      signupPassword !== signupPassword2
-                    }
-                    onClick={handleSignup}
-                  >
-                    Account aanmaken
-                  </Button>
-                  <button
-                    className="text-sm text-indigo-600 text-left"
-                    onClick={() => {
-                      setLoginEmail('');
-                      setLoginPassword('');
-                      setLoginError('');
-                      setSignupPassword('');
-                      setSignupPassword2('');
-                      setSignupError('');
-                      setAuthMode('login');
-                    }}
-                  >
-                    Terug naar inloggen
-                  </button>
-                </div>
-              </Card>
-            )}
-          </div>
+            </div>
+          ) : (
+            <div className="max-w-md mx-auto">
+              {authMode === 'login' ? (
+                <Card title="Log in">
+                  <div className="grid grid-cols-1 gap-4">
+                    <TextInput value={loginEmail} onChange={setLoginEmail} placeholder="E-mail (@student.nhlstenden.com)" />
+                    <TextInput
+                      type="password"
+                      value={loginPassword}
+                      onChange={setLoginPassword}
+                      placeholder="Wachtwoord of code"
+                    />
+                    {loginEmail && !emailValid(loginEmail) && (
+                      <div className="text-sm text-rose-600">Alleen adressen eindigend op @student.nhlstenden.com zijn toegestaan.</div>
+                    )}
+                    {loginError && <div className="text-sm text-rose-600">{loginError}</div>}
+                    <Button
+                      className="bg-indigo-600 text-white"
+                      disabled={!loginEmail.trim() || !emailValid(loginEmail) || !loginPassword.trim()}
+                      onClick={handleLogin}
+                    >
+                      Log in
+                    </Button>
+                    <button
+                      className="text-sm text-indigo-600 text-left"
+                      onClick={() => {
+                        setSignupEmail('');
+                        setSignupName('');
+                        setSignupPassword('');
+                        setSignupPassword2('');
+                        setSignupError('');
+                        setAuthMode('signup');
+                      }}
+                    >
+                      Account aanmaken
+                    </button>
+                  </div>
+                </Card>
+              ) : (
+                <Card title="Account aanmaken">
+                  <div className="grid grid-cols-1 gap-4">
+                    <TextInput
+                      value={signupEmail}
+                      onChange={(v) => {
+                        setSignupEmail(v);
+                        setSignupName(nameFromEmail(v));
+                      }}
+                      placeholder="E-mail (@student.nhlstenden.com)"
+                    />
+                    {signupEmail && !emailValid(signupEmail) && (
+                      <div className="text-sm text-rose-600">Alleen adressen eindigend op @student.nhlstenden.com zijn toegestaan.</div>
+                    )}
+                    <TextInput value={signupName} onChange={setSignupName} placeholder="Volledige naam" />
+                    <TextInput
+                      type="password"
+                      value={signupPassword}
+                      onChange={setSignupPassword}
+                      placeholder="Wachtwoord"
+                    />
+                    <TextInput
+                      type="password"
+                      value={signupPassword2}
+                      onChange={setSignupPassword2}
+                      placeholder="Bevestig wachtwoord"
+                    />
+                    {signupError && <div className="text-sm text-rose-600">{signupError}</div>}
+                    <Button
+                      className="bg-indigo-600 text-white"
+                      disabled={
+                        !signupEmail.trim() ||
+                        !signupName.trim() ||
+                        !emailValid(signupEmail) ||
+                        !signupPassword.trim() ||
+                        signupPassword !== signupPassword2
+                      }
+                      onClick={handleSignup}
+                    >
+                      Account aanmaken
+                    </Button>
+                    <button
+                      className="text-sm text-indigo-600 text-left"
+                      onClick={() => {
+                        setLoginEmail('');
+                        setLoginPassword('');
+                        setLoginError('');
+                        setSignupPassword('');
+                        setSignupPassword2('');
+                        setSignupError('');
+                        setAuthMode('login');
+                      }}
+                    >
+                      Terug naar inloggen
+                    </button>
+                  </div>
+                </Card>
+              )}
+            </div>
+          )
         ) : showBadges ? (
           <div className="max-w-3xl mx-auto">
 


### PR DESCRIPTION
## Summary
- Let Student component accept optional preview ID to display a student's data without requiring login
- Use local preview state in admin pages to view any student without affecting login status
- Simplify admin preview route with standalone component

## Testing
- `npm test -- --watchAll=false` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ade74ef858832ebb4a462ba9452ae4