### PR TITLE
feat: add admin logout button

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -13,7 +13,7 @@ import usePersistentState from './hooks/usePersistentState';
 
 const BADGE_POINTS = 50;
 
-export default function Admin() {
+export default function Admin({ onLogout = () => {} }) {
   const [students, setStudents] = useStudents();
   const [groups, setGroups] = useGroups();
   const [awards, setAwards] = useAwards();
@@ -253,6 +253,13 @@ export default function Admin() {
       </nav>
 
       <div className="space-y-4">
+        <div className="flex items-center justify-between p-4">
+          <span className="bg-white/90 px-2 py-1 rounded">Ingelogd als beheerder</span>
+          <Button className="bg-indigo-600 text-white" onClick={onLogout}>
+            Uitloggen
+          </Button>
+        </div>
+
       {page === 'manage-students' && (
         <Card title="Studenten beheren">
           <div className="grid grid-cols-1 gap-2">

--- a/src/App.js
+++ b/src/App.js
@@ -90,7 +90,7 @@ export default function App() {
 
         {route === '/admin' ? (
           isAdmin ? (
-            <Admin />
+            <Admin onLogout={logoutAdmin} />
           ) : (
             <Auth
               onAdminLogin={() => {


### PR DESCRIPTION
## Summary
- add logout control at top of admin interface
- support admin logout via new onLogout prop

## Testing
- `npm test -- --watchAll=false` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aea836c57c832ebe29839dd36846aa