### PR TITLE
Remove unused hamburger menu

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,29 +27,10 @@ export default function App() {
 
   const [selectedStudentId, setSelectedStudentId] = usePersistentState('nm_points_current_student', '');
 
-  const [menuOpen, setMenuOpen] = useState(false);
-
   const logoutAdmin = () => {
     denyAdmin();
-    setMenuOpen(false);
     window.location.hash = '/';
   };
-
-  // Add proper menu management
-  useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (menuOpen && !event.target.closest('.menu-wrapper')) {
-        setMenuOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [menuOpen]);
-
-  // Add route change handler to close menu
-  useEffect(() => {
-    setMenuOpen(false);
-  }, [route]);
 
   return (
     <div className="relative min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 p-4 md:p-8 text-slate-800 overflow-hidden">
@@ -67,25 +48,6 @@ export default function App() {
       <div className="relative z-10 max-w-6xl mx-auto">
         <header className="app-header">
           <h1 className="app-title">Neuromarketing Housepoints</h1>
-          {route !== '/' && (
-            <div className="menu-wrapper">
-              <button
-                onClick={() => setMenuOpen(!menuOpen)}
-                className="menu-button"
-                aria-label="Menu"
-              >☰</button>
-              {menuOpen && (
-                <div className="dropdown">
-                  <a href="#/student" className="dropdown-link" onClick={() => setMenuOpen(false)}>Student</a>
-                  <a href="#/admin" className="dropdown-link" onClick={() => setMenuOpen(false)}>Beheer</a>
-
-                  {isAdmin && (
-                    <button onClick={logoutAdmin} className="dropdown-button">Uitloggen beheer</button>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
         </header>
 
         {route === '/admin' ? (

--- a/src/index.css
+++ b/src/index.css
@@ -242,7 +242,7 @@ select:focus {
   }
 }
 
-/* Header/menu styles */
+/* Header styles */
 .app-header {
   position: relative;
   margin-bottom: 1.5rem;
@@ -254,48 +254,3 @@ select:focus {
   text-align: center;
 }
 
-.menu-wrapper {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-  z-index: 50;
-}
-
-.menu-button {
-  background: none;
-  border: none;
-  padding: 0.5rem;
-  border-radius: 8px;
-  font-size: 24px;
-  cursor: pointer;
-}
-
-.dropdown {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  margin-top: 0.5rem;
-  background: #fff;
-  border: 1px solid #ccc;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
-  z-index: 50;
-  min-width: 160px;
-  padding: 0.25rem 0;
-}
-
-.dropdown-link,
-.dropdown-button {
-  display: block;
-  padding: 0.75rem 1rem;
-  text-decoration: none;
-  color: #000;
-}
-
-.dropdown-button {
-  width: 100%;
-  background: none;
-  border: none;
-  text-align: left;
-  cursor: pointer;
-}


### PR DESCRIPTION
## Summary
- Simplify admin logout and remove header menu logic
- Drop hamburger menu markup from app header
- Clean up header CSS by removing menu styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aea9442cb0832ebbf10700989cfb18